### PR TITLE
fix interaction time

### DIFF
--- a/lua/GameInfoManager.lua
+++ b/lua/GameInfoManager.lua
@@ -3075,8 +3075,8 @@ if string.lower(RequiredScript) == "lib/units/beings/player/states/playerstandar
 			managers.gameinfo:event("buff", "set_value", "die_hard", { value = value })
 		end
 		
-		local t = Application:time()
-		managers.gameinfo:event("player_action", "activate", "interact", { t = t, duration = timer })
+		local time = Application:time()
+		managers.gameinfo:event("player_action", "activate", "interact", { t = time, duration = timer })
 		managers.gameinfo:event("player_action", "set_data", "interact", { interact_id = interact_object:interaction().tweak_data })
 		
 		return _start_action_interact_original(self, t, input, timer, interact_object, ...)

--- a/lua/Interaction.lua
+++ b/lua/Interaction.lua
@@ -24,7 +24,7 @@ if string.lower(RequiredScript) == "lib/units/beings/player/states/playerstandar
 	end
 	
 	
-	function PlayerStandard:_check_interaction_locked(t) 
+	function PlayerStandard:_check_interaction_locked(t)
 		PlayerStandard.LOCK_MODE = WolfHUD:getSetting({"INTERACTION", "LOCK_MODE"}, 3)						--Lock interaction, if MIN_TIMER_DURATION is longer then total interaction time, or current interaction time
 		PlayerStandard.MIN_TIMER_DURATION = WolfHUD:getSetting({"INTERACTION", "MIN_TIMER_DURATION"}, 5)			--Min interaction duration (in seconds) for the toggle behavior to activate	
 		local is_locked = false
@@ -36,7 +36,7 @@ if string.lower(RequiredScript) == "lib/units/beings/player/states/playerstandar
 			elseif PlayerStandard.LOCK_MODE >= 3 then
 				is_locked = self._interact_params and (self._interact_params.timer >= PlayerStandard.MIN_TIMER_DURATION) -- lock interaction, when total timer time is longer then given time
 			elseif PlayerStandard.LOCK_MODE >= 2 then
-				is_locked = self._interact_expire_t and (t - (self._interact_expire_t - self._interact_params.timer) >= PlayerStandard.MIN_TIMER_DURATION) --lock interaction, when interacting longer then given time
+				is_locked = t - (self._interact_expire_t - self._interact_params.timer) >= PlayerStandard.MIN_TIMER_DURATION --lock interaction, when interacting longer then given time
 			end
 		end
 		


### PR DESCRIPTION
the parameter "t" was overriden by "local t" and then passed to the original function.
pretty sure this caused the bug we all searched for.

the changes in Interaction.lua are just a meaningless cleanup.