### PR TITLE
some small vanilla hud tweaks

### DIFF
--- a/lua/KillCounter.lua
+++ b/lua/KillCounter.lua
@@ -229,7 +229,7 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudteammate" then
 			self._kills_panel = self._panel:panel({
 				name = "kills_panel",
 				visible = not WolfHUD:getSetting({"CustomHUD", self._setting_prefix, "KILLCOUNTER", "HIDE"}, false),
-				w = 100,
+				w = 150,
 				h = 20,
 				x = 0,
 				halign = "right"

--- a/lua/KillCounter.lua
+++ b/lua/KillCounter.lua
@@ -205,6 +205,10 @@ elseif RequiredScript == "lib/managers/hudmanagerpd2" then
 		--TODO
 	end
 
+	function HUDManager:teampanels_height()
+		return (WolfHUD:getSetting({"CustomHUD", "PLAYER", "SHOW_ACCURACY"}, true) and not WolfHUD:getSetting({"CustomHUD", "PLAYER", "KILLCOUNTER", "HIDE"}, false)) and 140 or 120
+	end
+
 elseif string.lower(RequiredScript) == "lib/managers/hud/hudteammate" then
 
 	if not HUDManager.CUSTOM_TEAMMATE_PANELS then	--Custom HUD compatibility
@@ -212,17 +216,11 @@ elseif string.lower(RequiredScript) == "lib/managers/hud/hudteammate" then
 		local set_name_original = HUDTeammate.set_name
 		local set_state_original = HUDTeammate.set_state
 
-		function HUDTeammate:init(i, teammates_panel, ...)
-			if not HUDManager.CUSTOM_TEAMMATE_PANELS and WolfHUD:getSetting({"CustomHUD", "PLAYER", "SHOW_ACCURACY"}, true) and not WolfHUD:getSetting({"CustomHUD", "PLAYER", "KILLCOUNTER", "HIDE"}, false) then
-				teammates_panel:set_h(teammates_panel:h() + 5)
-				teammates_panel:set_y(teammates_panel:y() - 5)
-			end
-			init_original(self, i, teammates_panel, ...)
-			if not HUDManager.CUSTOM_TEAMMATE_PANELS then
-				self._setting_prefix = self._main_player and "PLAYER" or "TEAMMATE"
-				self:_init_killcount()
-				self:init_accuracy()
-			end
+		function HUDTeammate:init(...)
+			init_original(self, ...)
+			self._setting_prefix = self._main_player and "PLAYER" or "TEAMMATE"
+			self:_init_killcount()
+			self:init_accuracy()
 		end
 
 		function HUDTeammate:_init_killcount()


### PR DESCRIPTION
- fixed carry info overlapping with special pickup icons
- increased kill counter size, so its not get cut off when someone reaches a very high amount of kills (had this when my mate had over 1000 kills on cook off)