### PR TITLE
Rename the Cloaker Cocaine: "Cloakaine" instead of "Coke".

### DIFF
--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -387,7 +387,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		bike_part_light = 			"bike",
 		bike_part_heavy = 			"bike",
 		circuit =					"server",
-		cloaker_cocaine = 			"coke",
+		cloaker_cocaine = 			"cloakaine",
 		cloaker_gold = 				"gold",
 		cloaker_money = 			"money",
 		coke =						"coke",


### PR DESCRIPTION
A silly change for a silly game mode. The pun is strong with this one. [inspired by reddit.](https://www.reddit.com/r/paydaytheheist/comments/7a0dg5/petition_to_hotfix_and_rename_cloakers_cocaine_to/)