### PR TITLE
Fix for 2 crashes - EnemyHealth.lua

### DIFF
--- a/lua/EnemyHealthbar.lua
+++ b/lua/EnemyHealthbar.lua
@@ -327,10 +327,14 @@ elseif string.lower(RequiredScript) == "lib/units/beings/player/states/playersta
 				end
 			end
 
-			if not visible and self._last_unit and alive( self._last_unit ) then
+			if not visible and self._last_unit and alive( self._last_unit ) and self._last_unit:character_damage() then
 				health = self._last_unit:character_damage()._health * 10 or 0
-				max_health = self._last_unit:character_damage()._HEALTH_INIT * 10 or 0
-				name_id = self._last_unit:base()._tweak_table or "ENEMY"
+				max_health = (self._last_unit:character_damage()._HEALTH_INIT or 0) * 10
+				if not self._last_unit:base() then 
+					name_id = "ENEMY"
+				else
+					name_id = self._last_unit:base()._tweak_table or "ENEMY"
+				end
 
 				if name_id == "robbers_safehouse" and self._last_unit:interaction() then
 					name_id = CriminalsManager.convert_new_to_old_character_workname(self._last_unit:interaction().character or name_id)


### PR DESCRIPTION
This should fix 2 crasehs:
1. The mod crashes the game if you shoot at the doors locks
2. The mod crashes the game if you looking at forklift on Alesso heist.
Firstly - _last_unit doesn't seems to always have character_damage
And secondly - _HEALTH_INIT and _last_unit:base() doesn't always exists. I have no idea why, but this changes are fixing it.