### PR TITLE
Update README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,15 +1,14 @@
 # WolfHUD
 ## Description
-
 This is a Mod collection of several useful HUD altering mods.
 I've modified them and added features which I felt that were either needed or useful, or both.
 It was originally a recreated and updated version of GageHUD, since it was really painful to maintain with all the mixed up files.
-Over time I added more and more useful Scripts and currently it becomes kind of an All-in-One solution...
+Over time I added more and more useful scripts and currently it becomes kind of an All-in-One solution...
 Not sure if I want it to become that, but at least I added ingame Options to turn off functions you don't like. ;)
 
 I got the permission from **Seven, ViciousWalrus, Undeadsewer, FishTaco, friendIyfire and Terminator01** for the use of their scripts and from N**ervatel Hanging Closet Monster** for using his icons.
 
-**Huge thanks to [Kampfhörnchen](http://forums.lastbullet.net/member.php?action=profile&uid=19364) for creating a better logo and a banner.**
+**Huge thanks to [Kampfhörnchen](http://modworkshop.net/member.php?action=profile&uid=19364) for creating a better logo and a banner.**
 
 Keep in mind, that this is a development version. For a more stable release, get your version [here](http://paydaymods.com/mods/298/wolfhud).
 
@@ -28,21 +27,19 @@ To make this mod work you will need to install either [Better Lua injecTor](http
 2. Click on the **Download .ZIP** Button
 2. Open the downloaded archive, using WinRAR or 7Zip
 3. Extract the **WolfHUD-master** folder into your 'PAYDAY 2/mods' folder
-4. Rename the folder **WolfHUD-master** to **WolfHUD**
+4. Rename the folder **WolfHUD-master** to **WolfHUD** (if you want to)
 5. Start the game once. It will prompt you to update Federal Inventory and WolfHUD_Textures. Update both.
 
 ## If you don't want/like Inventory Icons
 To remove "Federal Inventory" go to your **PAYDAY 2/assets/mod_overrides/Federal Inventory** folder and delete the **guis** folder. Then open **revision.txt** and change the number to a higher one, to prevent future updates.
 
 ## Bug reports
-
 If you encounter any bugs, feel free to post about it on the issues tab!
 Please try to provide information from your crashlog and the actions you and your teammates were doing, when you crashed. ;)
 The Crashlog can be found at **%localappdata%/PAYDAY 2/crashlog.txt**.
 The BLT log can be found at **PAYDAY 2/mods/logs/**.
 
 ## Included Mods
-
 * [CustomHUD](https://bitbucket.org/pjal3urb/customhud/src) made by **Seven** modified by **me**
 * [HudPanelList](https://bitbucket.org/pjal3urb/hudlist/src/) made by **Seven**, modified by **me**
 * [KillCounter](https://bitbucket.org/pjal3urb/customhud/src) made by **Seven**, modified by **me**
@@ -55,29 +52,29 @@ The BLT log can be found at **PAYDAY 2/mods/logs/**.
 * [TabStats](https://steamcommunity.com/app/218620/discussions/15/618463738399320805/) made by **friendIyfire**
 * [Numeric Suspicion](https://github.com/cjur3/GageHud) made by **friendIyfire**, updated by **me**
 * Angeled Sight Visualisation, made by **me** (based on HoxHUD P4.1)
-* [EnemyHealthbar](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=15127) made by **Undeadsewer**, modified by **me**
+* [EnemyHealthbar](https://modworkshop.net/mydownloads.php?action=view_down&did=15157) made by **Undeadsewer**, modified by **me**
 * AdvAssault made by **me** (based on HoxHUD P4.1)
 * Dynamic Damage Indicator made by **me**
 * DamagePopups made by **me** (Uses [WaypointsManager](https://bitbucket.org/pjal3urb/waypoints) made by **Seven**)
 * [BurstFire](https://bitbucket.org/pjal3urb/burstfire/src) made by **Seven**
-* [Real Ammo](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=15108) made by **FishTaco**, modified by **me**
+* [Real Ammo](https://modworkshop.net/mydownloads.php?action=view_down&did=15108) made by **FishTaco**, modified by **me**
 * [No Spam](http://steamcommunity.com/app/218620/discussions/15/618457398976607330/) made by **Ahab**, **Seven**, **AmEyeBlind** & **money123451**, updated by **me**
-* [DrivingHUD](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=12982) made by **ViciousWalrus** and **Great Big Bushy Beard**, rewritten by **me**
-* [Real Weapon Names](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=15433) made by **(AD) Jaqueto**, updated by **Terminator01**
+* [DrivingHUD](https://modworkshop.net/mydownloads.php?action=view_down&did=12982) made by **ViciousWalrus** and **Great Big Bushy Beard**, rewritten by **me**
+* [Real Weapon Names](http://modworkshop.net/mydownloads.php?action=view_down&did=15433) made by **(AD) Jaqueto**, updated by **Terminator01**
 * [Buy all Assets](http://steamcommunity.com/app/218620/discussions/15/618458030689719683/) made by **=TBM= BangL**, rewritten by **me**
 * PrePlanManager made by **me**
 * ProfileMenu made by **me**
 * Equipment Tweaks made by **me**
 * Smaller Menu Tweaks
-  * [Always show Mod Icons](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=13975) made by **Slippai**, updated by **me**
-  * [Slider Values](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=14800) made by **Snh20**, modified by **me**
+  * [Always show Mod Icons](http://modworkshop.net/mydownloads.php?action=view_down&did=13975) made by **Slippai**, updated by **me**
+  * [Slider Values](http://modworkshop.net/mydownloads.php?action=view_down&did=14800) made by **Snh20**, modified by **me**
   * Show Weapon Names made by **me**
   * Show Skill Names made by **me**
-  * [Skillset Info](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=15294) made by **Fooksie**
+  * [Skillset Info](http://modworkshop.net/mydownloads.php?action=view_down&did=15294) made by **Fooksie**
   * Increased the maximum chars of custom Weapon/Mask/Skillset names
   * Federal Inventory (Mod Override), made by **Nervatel Hanging Closet Monster** and **Luffy**, updated by **me**
-    * [Weapon Icons](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=14240), [Melee Icons](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=13910) and [Mask Icons](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=13911) made by **Nervatel Hanging Closet Monster**
-    * [Throwables, Equipment, Armor and Heister Portraits](http://forums.lastbullet.net/mydownloads.php?action=view_down&did=13916) made by **Luffy**
+    * [Weapon Icons](https://modworkshop.net/mydownloads.php?action=view_down&did=14240), [Melee Icons](http://modworkshop.net/mydownloads.php?action=view_down&did=13910) and [Mask Icons](http://modworkshop.net/mydownloads.php?action=view_down&did=13911) made by **Nervatel Hanging Closet Monster**
+    * [Throwables, Equipment, Armor and Heister Portraits](http://modworkshop.net/mydownloads.php?action=view_down&did=13916) made by **Luffy**
 
 ## Localizations
 * English made by **me**


### PR DESCRIPTION
Fixing links to various mods. The LastBullet forum no longer seems to exist.

# Description
I have fixed up various links to the mods included, from Forum.Lastbullet to Modworkshop.

Fixes # [issue]
Several

## Type of change
Updating links so they go to Modworkshop.net and so on.

# How Has This Been Tested?
I first checked by copying the links, then swapping out the "forums.lastbullet" with "modworkshop".

# Checklist:
- [X] My changes generate no new warnings