### PR TITLE
Check that chnmod is enabled before setting custom locale

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1359,7 +1359,7 @@ if not _G.WolfHUD then
 				custom_lang = "korean"
 			else
 				for _, mod in pairs(BLT and BLT.Mods:Mods() or {}) do
-					if mod:GetName() == "ChnMod" then
+					if mod:GetName() == "ChnMod" and mod:IsEnabled() then
 						custom_lang = "chinese"
 						break
 					end


### PR DESCRIPTION
# Description

If you have chnmod installed but disabled WolfHud still loads the Chinese resources.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran WolfHUD with ChnMod installed and both enabled and disabled to make sure it loaded the correct resources file.

# Checklist:

- [x] My changes generate no new warnings
