### PR TITLE
Changed check ChnMod mod name to trigger Chinese language properly

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1375,7 +1375,7 @@ if not _G.WolfHUD then
 				custom_lang = "korean"
 			else
 				for _, mod in pairs(BLT and BLT.Mods:Mods() or {}) do
-					if mod:GetName() == "ChnMod" and mod:IsEnabled() then
+					if mod:GetName() == "ChnMod (Patch)" and mod:IsEnabled() then
 						custom_lang = "chinese"
 						break
 					end


### PR DESCRIPTION
- [x] My changes generate no new warnings

Nothing much. I sent a pull request just to change ChnMod name to trigger Chinese language on WolfHUD mod properly. (in order to load chinese.json file instead of english.json when the user is using Chinese language) 

- Old Name of ChnMod in mod.txt iirc : ChnMod.  
- New Name: ChnMod (Patch)  
Source: of the ChnMod: [Link](https://coding.net/u/Dr_Newbie/p/chnmod_patch/git/blob/master/mods/chnmod_patch/mod.txt)

# How Has This Been Tested?  
I've tested by adding chnmod to force my game used Chinese language. Here is the result.

- [x] Tested with old name. The WolfHUD's Chinese language won't be triggered so it choose  english.json file and loaded that file instead.  
![WolfHUD with old ChnMod name#1](https://i.imgur.com/saj26lT.jpg)  
![WolfHUD with old ChnMod name#2](https://i.imgur.com/MZOm8rK.jpg)  

- [x] Tested with new name. The WolfHUD's Chinese language will be triggered properly
![WolfHUD with new ChnMod name#1](https://i.imgur.com/vm0fYmp.jpg)  
![WolfHUD with new ChnMod name#2](https://i.imgur.com/McVRdtC.jpg)  
