### PR TITLE
Crashfix: Null checks for when reconnecting while ecm jammer is active

### DIFF
--- a/lua/GameInfoManager.lua
+++ b/lua/GameInfoManager.lua
@@ -2319,7 +2319,7 @@ if string.lower(RequiredScript) == "lib/units/equipment/ecm_jammer/ecmjammerbase
 	end
 
 	function ECMJammerBase:_set_feedback_active(state, ...)
-		if not state and self._feedback_active then
+		if not state and self._feedback_active and managers.network and managers.network:session() and managers.network:session():local_peer() and managers.network:session():local_peer():id() then
 			local peer_id = managers.network:session():local_peer():id()
 
 			if self._owner_id == peer_id and managers.player:has_category_upgrade("ecm_jammer", "can_retrigger") then


### PR DESCRIPTION
# Description

I once crashed by a null pointer exception on that "local peer = ..." line, while i reconnected as client in stealth, so i have added some null checks to prevent this.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've played, and i never crashed for the same reason again. wolfhuds jammer related stuff still works when it should.

# Checklist:

- [x] My changes generate no new warnings
