### PR TITLE
AdvAssault: Revive menu callback code to change assault banner position

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -758,6 +758,11 @@ if not _G.WolfHUD then
 					end
 				end
 			end,
+			["AssaultBanner"] = function(setting, value)
+				if managers.hud and managers.hud.change_assaultbanner_setting then
+					managers.hud:change_assaultbanner_setting(tostring(setting[#setting]), value)
+				end
+			end,
 			["TabStats"] = function(setting, value)
 				if managers.hud and managers.hud.change_tabstats_setting then
 					managers.hud:change_tabstats_setting(tostring(setting[#setting]), value)

--- a/lua/AdvAssault.lua
+++ b/lua/AdvAssault.lua
@@ -176,7 +176,6 @@ if string.lower(RequiredScript) == "lib/managers/hud/hudassaultcorner" then
 		end
 	end
 elseif string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
-	local _change_vanillahud_setting_original = HUDManager._change_vanillahud_setting or function(...) end
 	local _create_downed_hud_original = HUDManager._create_downed_hud
 	local _create_custody_hud_original = HUDManager._create_custody_hud
 
@@ -192,12 +191,10 @@ elseif string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		return self._assault_locked
 	end
 
-	function HUDManager:_change_vanillahud_setting(setting)
+	function HUDManager:change_assaultbanner_setting(setting, value)
 		if self._hud_assault_corner then
-			if setting == "assault_banner_position" then
+			if setting == "POSITION" then
 				self._hud_assault_corner:update_banner_pos()
-			else
-				_change_vanillahud_setting_original(self, setting)
 			end
 		end
 	end


### PR DESCRIPTION
# Description

Another code part i just stumbled upon..
seems like  HUDManager:_change_vanillahud_setting() was there as menu callback once?
It is in fact dead code for now. It never gets called anywhere.
This patch properly revives its functionality with current wolfhud corebase. (i think)

## Type of change

Re-implementation of dead code

# How Has This Been Tested?

It did not.

# Checklist:

- [x] My changes generate no new warnings
