### PR TITLE
Joker Hud Fix + Joker Nameplate Toggle

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -101,6 +101,7 @@ if not _G.WolfHUD then
 					},
 				},
 				USE_REAL_AMMO 						= true,
+				ENABLE_JOKER_FLOATING_INFO			= true
 			},
 			HUDChat = {
 				CHAT_WAIT_TIME							= 10,		--Time before chat fades out, 0 = never

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -1156,6 +1156,13 @@ if WolfHUD then
 						value = {"CustomHUD", "USE_REAL_AMMO"},
 					},
 					{
+						type = "toggle",
+						name_id = "enable_joker_floating_title",
+						desc_id = "enable_joker_floating_desc",
+						visible_reqs = {}, enabled_reqs = {},
+						value = {"CustomHUD", "ENABLE_JOKER_FLOATING_INFO"},
+					},
+					{
 						type = "divider",
 						size = 16,
 					},

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -2080,7 +2080,7 @@ if WolfHUD then
 								type = "toggle",
 								name_id = "wolfhud_hudlist_show_own_minions_only_title",
 								desc_id = "wolfhud_hudlist_show_own_minions_only_desc",
-								value = {"HUDList", "LEFT_LIST", "show_minions"},
+								value = {"HUDList", "LEFT_LIST", "show_own_minions_only"},
 								visible_reqs = {},
 								enabled_reqs = {
 									{ setting = { "HUDList", "ENABLED" }, invert = false },

--- a/loc/english.json
+++ b/loc/english.json
@@ -286,6 +286,10 @@
 	"wolfhud_pacified_civs_desc" : "Change the waypoint of untied civilians, while they are pacified.",
 	"wolfhud_use_realammo_title" : "Use Real Ammo",
 	"wolfhud_use_realammo_desc" : "Shows ammo left, not taking the rounds in your current magazine into account.",
+
+	"enable_joker_floating_title" : "Enable Joker Nameplates",
+	"enable_joker_floating_desc" : "Shows joker name and health above them.",
+
 	"wolfhud_enable_burstmode_title" : "Enable Burst mode",
 	"wolfhud_enable_burstmode_desc" : "Enable a burst fire mode for your weapons.",
 

--- a/lua/CustomWaypoints.lua
+++ b/lua/CustomWaypoints.lua
@@ -511,6 +511,8 @@ if RequiredScript == "lib/managers/hudmanager" then
 
 		if event == "add" then
 			local unit_tweak = data.unit:base() and data.unit:base()._tweak_table
+			local enable_joker_floating_info = WolfHUD:getSetting({"CustomHUD", "ENABLE_JOKER_FLOATING_INFO"}, true)
+
 			local params = {
 				unit = data.unit,
 				offset = Vector3(0, 0, 30),
@@ -518,7 +520,7 @@ if RequiredScript == "lib/managers/hudmanager" then
 				scale = 1.25,
 				health_bar = {
 					type = "icon",
-					show = true,
+					show = enable_joker_floating_info,
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_health",
 					--texture_rect = {0, 0, 64, 64},
@@ -527,7 +529,7 @@ if RequiredScript == "lib/managers/hudmanager" then
 				},
 				health_shield = {
 					type = "icon",
-					show = true,
+					show = enable_joker_floating_info,
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_shield",
 					--texture_rect = {0, 0, 64, 64},
@@ -536,14 +538,14 @@ if RequiredScript == "lib/managers/hudmanager" then
 				},
 				health_bg = {
 					type = "icon",
-					show = true,
+					show = enable_joker_floating_info,
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_radialbg",
 					--texture_rect = {0, 0, 64, 64},
 				},
 				health_dmg = {
 					type = "icon",
-					show = true,
+					show = enable_joker_floating_info,
 					scale = 1.65,
 					texture = "guis/textures/pd2/hud_radial_rim",
 					--texture_rect = {0, 0, 64, 64},
@@ -552,12 +554,12 @@ if RequiredScript == "lib/managers/hudmanager" then
 				},
 				name = {
 					type = "label",
-					show = true,
+					show = enable_joker_floating_info,
 					text = WolfHUD:getCharacterName(unit_tweak, true)
 				},
 				kills = {
 					type = "label",
-					show = true,
+					show = enable_joker_floating_info,
 					text = string.format("%s %d", utf8.char(57364), data.kills or 0),
 					color = Color.white,
 					alpha = 0.8,


### PR DESCRIPTION
# Bugfix (only show own jokers)

The option to show only your own jokers in the UI was broken due to an incorrect value mapping in the options menu. This PR will fix that feature.

# Feature (joker nameplate toggle)

Games with many jokers become visually crowded when every joker has a name and large health radial floating above them. Secondarily, there are very popular mods which provide joker nameplate information (such as Keepers). Without a toggle, users are left hard coding a workaround or living with the result.

This adds a quick-fix toggle that can enable or disable the showing of joker health radials. I haven't deep dived into the entire library, so I'm not sure if there is a place higher-up in the code hierarchy to disable the nameplates.

## Notes

Only the English localization is provided.