### PR TITLE
Add heat percentage to contract broker

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -449,6 +449,7 @@ if not _G.WolfHUD then
 				SHOW_WEAPON_MINI_ICONS 					= true,
 				USE_REAL_WEAPON_NAMES 					= true,
 				SHOW_SKILL_NAMES 						= true,
+				SHOW_CONTRACTOR_JOB_HEAT				= true,
 				CUSTOM_TAB_NAMES = {
 					primaries 							= { "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" },
 					secondaries 						= { "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" },

--- a/OptionMenus.lua
+++ b/OptionMenus.lua
@@ -3841,6 +3841,17 @@ if WolfHUD then
 					},
 					{
 						type = "toggle",
+						name_id = "wolfhud_show_contractor_job_heat_title",
+						desc_id = "wolfhud_show_contractor_job_heat_desc",
+						value = {"INVENTORY", "SHOW_CONTRACTOR_JOB_HEAT"},
+						visible_reqs = {}, enabled_reqs = {},
+					},
+					{
+						type = "divider",
+						size = 24,
+					},
+					{
+						type = "toggle",
 						name_id = "wolfhud_enable_burstmode_title",
 						desc_id = "wolfhud_enable_burstmode_desc",
 						value = {"EQUIPMENT", "ENABLE_BURSTMODE"},

--- a/loc/english.json
+++ b/loc/english.json
@@ -265,6 +265,8 @@
 	"wolfhud_inventory_names_desc" : "Show the names of your weapons, armor, deployables, etc. inside its box in the inventory.",
 	"wolfhud_skill_names_title" : "Show Skill Names",
 	"wolfhud_skill_names_desc" : "Always show the names of skills in the skilltree view.",
+	"wolfhud_show_contractor_job_heat_title":"Show Contractor Heat",
+	"wolfhud_show_contractor_job_heat_desc":"Shows job heat in the contract broker list.",
 	"wolfhud_show_mini_icons_title" : "Always show Mini-Icons",
 	"wolfhud_show_mini_icons_desc" : "Always show the mod icons of all weapons, not just the selected one.",
 	"wolfhud_no_slowmotion_title" : "No Slow Motion",

--- a/lua/ContractHeat.lua
+++ b/lua/ContractHeat.lua
@@ -36,16 +36,15 @@ function ContractBrokerHeistItem:make_fine_text(text)
 end
 
 function ContractBrokerHeistItem:get_job_heat_text(job_id)
-	local heat_text = ""
-	local heat_color = Color(1,0,1)
-	local multiplier = managers.job:get_job_heat(job_id)
-	local exp_multi  = managers.job:heat_to_experience_multiplier(multiplier)
-	local icon_multi = exp_multi*20-20
+	local heat_text       = ""
+	local heat_color      = Color(1,0,1)
+	local exp_multiplier  = managers.job:heat_to_experience_multiplier(managers.job:get_job_heat(job_id))
+	local exp_percent     = ((1 - exp_multiplier)*-1)*100
 
-    if icon_multi ~= 0 then
-		heat_sequence = (icon_multi>0 and ("+"):rep(math.ceil(icon_multi)) or ("-"):rep(-math.floor(icon_multi)))
-		heat_text = heat_sequence.." ("..math.abs(((1 - exp_multi)*-1)*100).."%)"
-        heat_color = (icon_multi > 0 and Color.yellow) or Color('E55858')
+	if exp_percent ~= 0 then
+		local prefix  = exp_percent > 0 and "+" or ""
+		heat_text = "("..prefix..exp_percent.."%)"
+        heat_color = exp_percent > 0 and Color.yellow or Color('E55858')
     end
 
 	return heat_text, heat_color

--- a/lua/ContractHeat.lua
+++ b/lua/ContractHeat.lua
@@ -1,0 +1,50 @@
+-- CONFIG **********************************************************************
+
+-- OVERRIDES *******************************************************************
+local init_original = ContractBrokerHeistItem.init
+function ContractBrokerHeistItem:init(...) -- parent_panel, job_data, idx
+
+	init_original(self, ...)
+
+	if WolfHUD:getSetting({"INVENTORY", "SHOW_CONTRACTOR_JOB_HEAT"}, true) then
+		local heat_text, heat_color = self:get_job_heat_text(self._job_data.job_id)
+		
+		local heat = self._panel:text({
+			alpha = 1,
+			vertical = "top",
+			layer = 1,
+			align = "right",
+			halign = "right",
+			valign = "top",
+			text = heat_text,
+			font = tweak_data.menu.pd2_large_font,
+			font_size = tweak_data.menu.pd2_medium_font_size * 0.8,
+			color = heat_color
+		})
+		self:make_fine_text(heat)
+		heat:set_right(self._panel:right() - 10)
+		heat:set_top(10)
+	end
+end
+
+-- FUNCTION LIB ****************************************************************
+function ContractBrokerHeistItem:make_fine_text(text)
+	local x, y, w, h = text:text_rect()
+
+	text:set_size(w, h)
+	text:set_position(math.round(text:x()), math.round(text:y()))
+end
+
+function ContractBrokerHeistItem:get_job_heat_text(job_id)
+	local heat_text = ""
+	local heat_color = Color(1,0,1)
+	local multiplier = managers.job:get_job_heat(job_id)
+	local exp_multi  = managers.job:heat_to_experience_multiplier(multiplier)*20-20
+
+    if exp_multi ~= 0 then
+        heat_text = (exp_multi>0 and ("+"):rep(math.ceil(exp_multi)) or ("-"):rep(-math.floor(exp_multi)))
+        heat_color = (exp_multi > 0 and Color.yellow) or Color('E55858')
+    end
+
+	return heat_text, heat_color
+end

--- a/lua/ContractHeat.lua
+++ b/lua/ContractHeat.lua
@@ -39,11 +39,13 @@ function ContractBrokerHeistItem:get_job_heat_text(job_id)
 	local heat_text = ""
 	local heat_color = Color(1,0,1)
 	local multiplier = managers.job:get_job_heat(job_id)
-	local exp_multi  = managers.job:heat_to_experience_multiplier(multiplier)*20-20
+	local exp_multi  = managers.job:heat_to_experience_multiplier(multiplier)
+	local icon_multi = exp_multi*20-20
 
-    if exp_multi ~= 0 then
-        heat_text = (exp_multi>0 and ("+"):rep(math.ceil(exp_multi)) or ("-"):rep(-math.floor(exp_multi)))
-        heat_color = (exp_multi > 0 and Color.yellow) or Color('E55858')
+    if icon_multi ~= 0 then
+		heat_sequence = (icon_multi>0 and ("+"):rep(math.ceil(icon_multi)) or ("-"):rep(-math.floor(icon_multi)))
+		heat_text = heat_sequence.." ("..math.abs(((1 - exp_multi)*-1)*100).."%)"
+        heat_color = (icon_multi > 0 and Color.yellow) or Color('E55858')
     end
 
 	return heat_text, heat_color

--- a/mod.txt
+++ b/mod.txt
@@ -89,6 +89,7 @@
 		{ "hook_id" : "lib/units/vehicles/vehicledrivingext", 					"script_path" : "lua/CustomWaypoints.lua" },
 
 		{ "hook_id" : "lib/managers/group_ai_states/groupaistatebase", 			"script_path" : "lua/PacifiedCivs.lua" },
+		{ "hook_id"	: "lib/managers/menu/items/contractbrokerheistitem",		"script_path" : "lua/ContractHeat.lua"},
 
 		{ "hook_id" : "lib/managers/hudmanagerpd2", 							"script_path" : "lua/HUDChat.lua" },
 		{ "hook_id" : "lib/managers/hud/hudchat", 								"script_path" : "lua/HUDChat.lua" },


### PR DESCRIPTION
# Description

Adds a toggle option to enable/disable showing job heat in the contract broker menu. Only English localization is provided. [Image Preview](https://i.imgur.com/cCiFdvn.png)

ref https://github.com/Kamikaze94/WolfHUD/issues/216