### PR TITLE
add check if self._mouse_click is nil

### DIFF
--- a/lua/MenuTweaks.lua
+++ b/lua/MenuTweaks.lua
@@ -317,7 +317,7 @@ elseif string.lower(RequiredScript) == "lib/managers/menu/blackmarketgui" then
 	function BlackMarketGui:mouse_clicked(...)
 		BlackMarketGui_mouse_clicked_original(self, ...)
 
-		if not self._enabled then
+		if not self._enabled or self._mouse_click == nil then
 			return
 		end
 


### PR DESCRIPTION
Probably fixes #831,#829,#830 

Reporters says what this change disables quick weapon equip on double RMB click, but i dont remember if this feature was in wolfhud before
I dont check it myself
