### PR TITLE
Fixed crash with HUD scaling and spacing mod

### DIFF
--- a/lua/HUDChat.lua
+++ b/lua/HUDChat.lua
@@ -29,6 +29,7 @@ if RequiredScript == "lib/managers/hud/hudchat" then
 	function HUDChat:init(ws, hud)
 		local fullscreen = managers.hud:script(PlayerBase.PLAYER_INFO_HUD_FULLSCREEN_PD2)
 
+		self._hud_panel = fullscreen.panel
 		self._x_offset = (fullscreen.panel:w() - hud.panel:w()) / 2
 		self._y_offset = (fullscreen.panel:h() - hud.panel:h()) / 2
 		self._esc_callback = callback(self, self, "esc_key_callback")


### PR DESCRIPTION
# Description

Adds missing parameter self._hud_panel so HUDChat:remove doesn't crash the game.
Which in turn makes the mod work with this mod: https://modworkshop.net/mod/20849
(White space change seems to be done by GitHub not entirely sure why it keeps forcing that)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Generally this shouldn't cause any issues. It's simply a value that has been yanked from the game. Its absence actaully causes more issues. But I did test to confirm that it works fine now with the mod mentioned before.

# Checklist:

- [x] My changes generate no new warnings
