### PR TITLE
Fix crash when loading plan in 199.6

### DIFF
--- a/lua/PrePlanManager.lua
+++ b/lua/PrePlanManager.lua
@@ -639,7 +639,7 @@ elseif requiredScript == "lib/managers/preplanningmanager" then
 			end
 
 			for id, mission_element in pairs(saved_assets) do
-				money_costs = money_costs + self:_get_type_cost(mission_element.type)
+				money_costs = money_costs + self:get_type_cost(mission_element.type)
 				favours = favours + self:get_type_budget_cost(mission_element.type, 0)
 			end
 		end


### PR DESCRIPTION
The _get_type_cost function was renamed to get_type_cost, rename it here so that clients don't crash when loading plans.

Fixes #865 

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My changes generate no new warnings
