### PR TITLE
Fixed escort NPC name in "Breakfast in Tijuana"

### DIFF
--- a/WolfHUDTweakData.lua
+++ b/WolfHUDTweakData.lua
@@ -183,7 +183,7 @@ function WolfHUDTweakData:init()
 		[ "boris" ]								= { default = "wolfhud_enemy_boris" },
 		[ "spa_vip" ]							= { default = "wolfhud_enemy_spa_vip" },
 		[ "spa_vip_hurt" ]						= { default = "wolfhud_enemy_spa_vip_hurt" },
-		[ "escort_criminal" ] 					= { default = "Please edit later..." },
+		[ "escort_criminal" ] 					= { default = "wolfhud_enemy_escort_hajrudin" },
 		[ "old_hoxton_mission" ] 				= { default = "wolfhud_enemy_locke_mission", hox_1 = "wolfhud_enemy_old_hoxton_mission", hox_2 = "wolfhud_enemy_old_hoxton_mission", rvd1 = "wolfhud_enemy_reservoirdogs", rvd2 = "wolfhud_enemy_reservoirdogs" },
 		[ "hector_boss" ] 						= { default = "wolfhud_enemy_hector_boss" },
 		[ "hector_boss_no_armor" ] 				= { default = "wolfhud_enemy_hector_boss_no_armor" },

--- a/loc/chinese.json
+++ b/loc/chinese.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "加内特 CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "粉先生",
 	"wolfhud_enemy_escort_bain_locke" : "洛克 / 贝恩",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "醉酒飞行员",
 	"wolfhud_enemy_escort" : "护送",
 	"wolfhud_enemy_boris" : "鲍里斯",

--- a/loc/dutch.json
+++ b/loc/dutch.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "Garnett CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "Drunk Pilot",
 	"wolfhud_enemy_escort" : "Escort",
 	"wolfhud_enemy_boris" : "Boris",

--- a/loc/english.json
+++ b/loc/english.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "Garnett CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "Drunk Pilot",
 	"wolfhud_enemy_escort" : "Escort",
 	"wolfhud_enemy_boris" : "Boris",

--- a/loc/french.json
+++ b/loc/french.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "Comptable de Garnett",
 	"wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "Pilote bourré",
 	"wolfhud_enemy_escort" : "Escorte",
 	"wolfhud_enemy_boris" : "Boris",

--- a/loc/german.json
+++ b/loc/german.json
@@ -188,6 +188,7 @@
 	"wolfhud_enemy_escort_cfo" : "Garnett CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "Betrunkener Pilot",
 	"wolfhud_enemy_escort" : "Escort",
 	"wolfhud_enemy_boris" : "Boris",

--- a/loc/italian.json
+++ b/loc/italian.json
@@ -178,6 +178,8 @@
     "wolfhud_enemy_escort_chinese_prisoner" : "Kazo",
     "wolfhud_enemy_escort_cfo" : "Direttore Finanziario di Garnet",
     "wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
+    "wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+    "wolfhud_enemy_escort_hajrudin" : "Hajrudin",
     "wolfhud_enemy_drunk_pilot" : "Pilota Ubriaco",
     "wolfhud_enemy_escort" : "Escort",
     "wolfhud_enemy_boris" : "Boris",

--- a/loc/korean.json
+++ b/loc/korean.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "가넷 CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "취한 파일럿",
 	"wolfhud_enemy_escort" : "호위자",
 	"wolfhud_enemy_boris" : "보리스",

--- a/loc/portuguese.json
+++ b/loc/portuguese.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "Garnett CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "Senhor Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "Piloto bêbado",
 	"wolfhud_enemy_escort" : "Escolta",
 	"wolfhud_enemy_boris" : "Boris",

--- a/loc/russian.json
+++ b/loc/russian.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "Фин. директор Гарнетта",
 	"wolfhud_enemy_escort_reservoirdogs" : "Мистер Розовый",
 	"wolfhud_enemy_escort_bain_locke" : "Лок / Бэйн",
+	"wolfhud_enemy_escort_hajrudin" : "Хайрудин",
 	"wolfhud_enemy_drunk_pilot" : "Пьяный пилот",
 	"wolfhud_enemy_escort" : "Сопровождающий",
 	"wolfhud_enemy_boris" : "Борис",

--- a/loc/spanish.json
+++ b/loc/spanish.json
@@ -186,6 +186,7 @@
 	"wolfhud_enemy_escort_cfo" : "Garnett CFO",
 	"wolfhud_enemy_escort_reservoirdogs" : "Mr. Pink",
 	"wolfhud_enemy_escort_bain_locke" : "Locke / Bain",
+	"wolfhud_enemy_escort_hajrudin" : "Hajrudin",
 	"wolfhud_enemy_drunk_pilot" : "PILOTO BORRACHO",
 	"wolfhud_enemy_escort" : "ESCOLTA",
 	"wolfhud_enemy_boris" : "Boris",


### PR DESCRIPTION
# Description

Fixed escort NPC name in "Breakfast in Tijuana"
Also fixed missing translation string for Italian language

![image](https://user-images.githubusercontent.com/3299036/102429812-53411180-401b-11eb-98c8-b717ed80fc0e.png)


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run the "Breakfast in Tijuana" heist and look at the escort NPC name