### PR TITLE
Added triad enemies to right hud list

### DIFF
--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -293,6 +293,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		mobster = 					{ type_id = "thug",			category = "enemies",	long_name = "wolfhud_enemy_mobster" 				},
 		biker = 					{ type_id = "thug",			category = "enemies",	long_name = "wolfhud_enemy_biker" 					},
 		biker_escape = 				{ type_id = "thug",			category = "enemies",	long_name = "wolfhud_enemy_biker" 					},
+		triad =						{ type_id = "thug",			category = "enemies",	long_name = "wolfhud_enemy_triad" 					},
 		tank = 						{ type_id = "tank",			category = "enemies",	long_name = "wolfhud_enemy_tank" 					},
 		tank_hw = 					{ type_id = "tank",			category = "enemies",	long_name = "wolfhud_enemy_tank_hw" 				},
 		tank_medic = 				{ type_id = "tank",			category = "enemies",	long_name = "wolfhud_enemy_tank_medic" 				},


### PR DESCRIPTION
# Description

This just add an info for the right hud list about how many triad enemies there is in the dragon heist

# Type of change

not a fix, just an small addition

# How Has This Been Tested?

I just added this line and tried it out, and yes the number of triad members showed up just fine with the "thug" symbol, no bugs found
