### PR TITLE
Fix Dragon Heist C4 and Timelock Timers from hanging

### DIFF
--- a/lua/GameInfoManager.lua
+++ b/lua/GameInfoManager.lua
@@ -2142,8 +2142,7 @@ if string.lower(RequiredScript) == "lib/network/handlers/unitnetworkhandler" the
 
 end
 
-if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" and not CopDamage._game_info_manager_loaded then
-    CopDamage._game_info_manager_loaded = true
+if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" then
 
 	local convert_to_criminal_original = CopDamage.convert_to_criminal
 	local _on_damage_received_original = CopDamage._on_damage_received

--- a/lua/GameInfoManager.lua
+++ b/lua/GameInfoManager.lua
@@ -168,6 +168,12 @@ if string.lower(RequiredScript) == "lib/setups/setup" then
 			[140821] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Cursed kill room safe 5 timer
 			[140822] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Cursed kill room safe 5 timer
 			[140823] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Cursed kill room safe 5 timer
+			[136015] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Dragon Heist Time Lock
+			[138640] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Dragon Heist C4 Trap 1 
+			[138940] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Dragon Heist C4 Trap 2 
+			[139540] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Dragon Heist C4 Trap 3
+			[139840] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Dragon Heist C4 Trap 4
+			[140140] = { pause = function(...) GameInfoManager._TIMER_CALLBACKS.overrides.stop_on_pause(...) end },	--Dragon Heist C4 Trap 5
 		}
 	}
 
@@ -2136,7 +2142,8 @@ if string.lower(RequiredScript) == "lib/network/handlers/unitnetworkhandler" the
 
 end
 
-if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" then
+if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" and not CopDamage._game_info_manager_loaded then
+    CopDamage._game_info_manager_loaded = true
 
 	local convert_to_criminal_original = CopDamage.convert_to_criminal
 	local _on_damage_received_original = CopDamage._on_damage_received


### PR DESCRIPTION
# Description

Fixes the C4 and Timelock Timers from freezing on the hud upon finishing.

Fixes #913

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Played through the heists a few times and tried all C4 events and timelock.
