### PR TITLE
Midland Ranch heist small fix

### DIFF
--- a/lua/HUDList.lua
+++ b/lua/HUDList.lua
@@ -474,6 +474,7 @@ if string.lower(RequiredScript) == "lib/managers/hudmanagerpd2" then
 		weapon =					"weapon",
 		weapon_glock =				"weapon",
 		weapon_scar =				"weapon",
+		ranc_weapon =				"weapon",
 		women_shoes = 				"shoes",
 		yayo = 						"coke",
 	}


### PR DESCRIPTION

# Description

small addition that fixes the hud weapon(Assault rifles) loot number for the Midland Ranch heist

Fixes # [issue]

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by loading up the Midland Ranch heist and opening/bagging the weapons

# Checklist:
