### PR TITLE
Fix crash regarding nil value for job_heat

### DIFF
--- a/lua/ContractHeat.lua
+++ b/lua/ContractHeat.lua
@@ -40,7 +40,10 @@ end
 function ContractBrokerHeistItem:get_job_heat_text(job_id)
 	local heat_text       = ""
 	local heat_color      = Color(1,0,1)
-	local exp_multiplier  = managers.job:heat_to_experience_multiplier(managers.job:get_job_heat(job_id))
+	-- This fixes an 'attempt to compare nil with number'
+	local job_heat		  = managers.job:get_job_heat(job_id)
+	if job_heat == nil then job_heat = 0 end 
+	local exp_multiplier  = managers.job:heat_to_experience_multiplier(job_heat)
 	local exp_percent     = ((1 - exp_multiplier)*-1)*100
 
 	if exp_percent ~= 0 then


### PR DESCRIPTION
Fix implemented and orientated by "Shaklin" in the "Show Contract XP" mod imported to counter a crash with custom maps.
# Description

The only actual change is before directly getting the 'heat to experience' value, a check is done to verify if the 'job heat' value is nil or not; if it is nil, it's value is substituted to "0" to fix this crash that happens in: "[string "lib/managers/jobmanager.lua"]:502: attempt to compare nil with number". This fix fixes any problems with custom heists of any sorts and any kind of heist XP calculation.

Fixes #  #952 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Game is running in the newest version with two custom maps (Enemy Spawner & Greenscreen) localized in "Custom Heists" and "Events" tab

## **Before Fix**
- Turn on game and select "Play Online/Offline"
- Select "Contract_Broker"
- Click on "Custom Heists" or "Events"
- Crash

## **After Fix**
- Turn on game and select "Play Online/Offline"
- Select "Contract_Broker"
- Click on "Custom Heists" and "Events"
- Nothing bad

# Checklist:

- [X] My changes generate no new warnings
